### PR TITLE
Finding snapshots may fail when destination directory doesn't exists

### DIFF
--- a/backup
+++ b/backup
@@ -108,6 +108,7 @@ _find() {
     local regex="$1" str=''
     local -a found
 
+    [[ -d "$destination" ]] || error "Destination directory does not exists: \"$destination\""
     cd "$destination"
     readarray -t found < <(find . -maxdepth 4 -mindepth 4 -type d | sed -r "s|^\.(.*)|$destination\1|" | sort -dr | grep "$regex")
 


### PR DESCRIPTION
When the destination directory does not exists, then the "cd"
silently fails, having the subsequent commands work from
the current directory with unkown consequences.

This can happen for example when the target directory is not mounted
or "snap" was not run initially.